### PR TITLE
fix: add missing base class 'Enum'

### DIFF
--- a/src/i2c/emc2101/emc2101_core.py
+++ b/src/i2c/emc2101/emc2101_core.py
@@ -80,7 +80,7 @@ CONVERSIONS_PER_SECOND = {
 }
 
 
-class ExternalSensorStatus:
+class ExternalSensorStatus(Enum):
     OK = "all good"
     FAULT1 = "open circuit or short to VDD"
     FAULT2 = "short circuit or short to GND"


### PR DESCRIPTION
fixes:

```
src/i2c/emc2101/emc2101_core.py:423: error: Incompatible return value type (got "str", expected "ExternalSensorStatus")  [return-value]
src/i2c/emc2101/emc2101_core.py:426: error: Incompatible return value type (got "str", expected "ExternalSensorStatus")  [return-value]
src/i2c/emc2101/emc2101_core.py:428: error: Incompatible return value type (got "str", expected "ExternalSensorStatus")  [return-value]
```